### PR TITLE
Synchronous computation: startup is cycle 0

### DIFF
--- a/tests/unit/test_algorithms_ncbb.py
+++ b/tests/unit/test_algorithms_ncbb.py
@@ -274,6 +274,7 @@ def test_no_value_selection_at_start_when_not_root(three_variables_pb):
     assert not comp.is_root
     assert comp.current_value is None
     comp.start()
+    comp.message_sender.reset_mock()  # reset startup messages
 
     # at startup, only the root select a value and send it to its children
     # as x2 is not the root of the pseudo tree, it should not select a variable


### PR DESCRIPTION
The startup phase (i.e. ``on_start() `` handlers) must be considered as the first cycle of the algorithm, during which messages can be send but not received. These messages will be received during the cycle 1.