### PR TITLE
Support for full python function in yaml dcop file

### DIFF
--- a/docs/usage/file_formats/dcop_format.yml
+++ b/docs/usage/file_formats/dcop_format.yml
@@ -82,6 +82,8 @@ external_variables:
 constraints:
   c1:
     # type: pydcop supports intentional and extensional constraints
+    # When using an intentional constraint, the constraint can be defined with a
+    # simple python expression (see c1) or a full python function (see c4)
     type: intention
     # Any valid python expression can be used as a function declaration and
     # any builtin python function can be used (e.g. abs, round, etc.).
@@ -101,6 +103,23 @@ constraints:
     # Real hard constraints are not supported, you can emulate them by defining
     # contraints  
     function: 1000 if var2 == var3 else 0
+  c4:
+    type: intention
+    # this is an example of a multi-line intentional constraints
+    # The `function` if a full python function
+    # Real hard constraints are not supported, you can emulate them by defining
+    # constraints as a full python function. The `def` line is omitted and will be
+    # automatically generated based on the dcops variables used in the function.
+    # The function MUST have a return statement in all execution paths.
+    # The yaml multi-line syntax is recommended (starting with `|`, as shown bellow)
+    # and the code must be 4-space indented.
+    function: |
+      if var1 == 2:
+          b= 4
+      else:
+          b = 2
+      return var1 + 2
+
   cost_d1:
     type: intention
     function: var1 * 0.8

--- a/pydcop/utils/expressionfunction.py
+++ b/pydcop/utils/expressionfunction.py
@@ -77,15 +77,17 @@ class ExpressionFunction(Callable, SimpleRepr):
 
         f_def = f"def f({', '.join([v for v in self.exp_vars])} ):\n"
         if not has_return:
-            f_def += f"    return {expression}"
+            f_def += f"    return {self._expression}"
         else:
-            f_def += expression.replace("\n", "\n    ")
+            self._expression = f"\n{self._expression}" \
+                if not self._expression.startswith("\n") \
+                else self._expression
+            f_def += self._expression.replace("\n", "\n    ")
 
         try:
             f_compiled = compile(f_def, '<string>', 'exec')
         except SyntaxError:
-            raise SyntaxError('Syntax error in string expression ' +
-                              str(expression))
+            raise SyntaxError(f"Syntax error in string expression: '{self._expression}'")
         g = dict(globals())
         local = {}
         try:
@@ -118,7 +120,8 @@ class ExpressionFunction(Callable, SimpleRepr):
     def partial(self, **kwargs):
         return ExpressionFunction(self.expression, **kwargs)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, **kwargs):
+        # Note that we only accept named arguments !
         l = kwargs.copy()
         l.update(self._fixed_vars)
 

--- a/pydcop/utils/expressionfunction.py
+++ b/pydcop/utils/expressionfunction.py
@@ -65,27 +65,40 @@ class ExpressionFunction(Callable, SimpleRepr):
         not match any of the variables found in the expression,
         a `ValueError` is raised.
         """
-        self._expression = expression
+        self._expression = expression.lstrip()
         self._fixed_vars = fixed_vars
 
-        try:
-            self._c = compile('_fres=' + str(expression), '<string>', 'exec')
-        except SyntaxError:
-            raise SyntaxError('Syntax error in string expression ' +
-                              str(expression))
-        f_vars = set(self._c.co_names)
-        f_vars.remove('_fres')
-        for v in fixed_vars:
-            if v not in f_vars:
-                raise ValueError('Cannot fix variable "{}" which is not '
-                                 'present in the expression ""'
-                                 .format(v, expression))
-
+        has_return, exp_vars = _analyse_ast(self._expression)
         # We want to allow using builtin function like abs, round, etc.
         # We must filter them out from the list of variables
         import sys
         builtins = dir(sys.modules["builtins"])
-        self._vars = [v for v in f_vars if v not in builtins]
+        self.exp_vars = [v for v in exp_vars if v not in builtins]
+
+        f_def = f"def f({', '.join([v for v in self.exp_vars])} ):\n"
+        if not has_return:
+            f_def += f"    return {expression}"
+        else:
+            f_def += expression.replace("\n", "\n    ")
+
+        try:
+            f_compiled = compile(f_def, '<string>', 'exec')
+        except SyntaxError:
+            raise SyntaxError('Syntax error in string expression ' +
+                              str(expression))
+        g = dict(globals())
+        local = {}
+        try:
+            exec(f_compiled, g, local)
+            self.exp_func = local["f"]
+        except SyntaxError:
+            raise SyntaxError(f"Syntax error in multi-line string expression {f_def}'")
+
+        for v in fixed_vars:
+            if v not in self.exp_vars:
+                raise ValueError('Cannot fix variable "{}" which is not '
+                                 'present in the expression ""'
+                                 .format(v, expression))
 
     @property
     def expression(self):
@@ -100,7 +113,7 @@ class ExpressionFunction(Callable, SimpleRepr):
         """
         :return: a set of variable names that must be set when calling f
         """
-        return [ v for v in self._vars if v not in self._fixed_vars]
+        return [ v for v in self.exp_vars if v not in self._fixed_vars]
 
     def partial(self, **kwargs):
         return ExpressionFunction(self.expression, **kwargs)
@@ -120,9 +133,8 @@ class ExpressionFunction(Callable, SimpleRepr):
             raise TypeError(
                 "Unexpected argument(s) " + str(unexpected))
 
-        exec(self._c, globals(), l)
-
-        return l['_fres']
+        res = self.exp_func(**l)
+        return res
 
     def __eq__(self, other):
         if type(self) != type(other):
@@ -136,7 +148,7 @@ class ExpressionFunction(Callable, SimpleRepr):
 
     def __repr__(self):
         return 'ExpressionFunction({}, {})'.format(self._expression,
-                                                   self._vars)
+                                                   self.exp_vars)
 
     def __hash__(self):
         return hash((self._expression, tuple(self._fixed_vars.items())))
@@ -148,11 +160,11 @@ class ExpressionFunction(Callable, SimpleRepr):
 
     @classmethod
     def _from_repr(cls, r):
-        fixed_vars =  r['fixed_vars']
+        fixed_vars = r['fixed_vars']
         del r['fixed_vars']
         args = {k: from_repr(v) for k, v in r.items()
                 if k not in ['__qualname__', '__module__']}
-        exp_fct =  cls(**args, **fixed_vars)
+        exp_fct = cls(**args, **fixed_vars)
         return exp_fct
 
 

--- a/tests/unit/test_dcop_relations.py
+++ b/tests/unit/test_dcop_relations.py
@@ -1452,6 +1452,24 @@ class RelationFromExpression(unittest.TestCase):
         self.assertIn(s2, r.dimensions)
         self.assertEqual(2, len(r.dimensions))
 
+    def test_relation_from_str_multiline(self):
+        d = pydcop.dcop.objects.VariableDomain("d", "d", [0, 1, 2])
+        s1 = ExternalVariable("s1", d, 0)
+        s2 = ExternalVariable("s2", d, 0)
+        expr = """
+b = s1 / 2
+return b * s2        
+        """
+        r = relation_from_str("test_rel", expr, [s1, s2])
+
+        self.assertEqual(r(s1=1, s2=3), 1.5)
+        self.assertEqual(r(s2=3, s1=4), 6)
+        self.assertIn(s1, r.dimensions)
+        self.assertIn(s2, r.dimensions)
+        self.assertEqual(2, len(r.dimensions))
+
+        self.assertEqual(r.expression, expr)
+
 
 class FindDependentRelations(unittest.TestCase):
     def test_no_relation(self):

--- a/tests/unit/test_dcop_serialization.py
+++ b/tests/unit/test_dcop_serialization.py
@@ -510,6 +510,29 @@ class TestDcopLoadConstraints(unittest.TestCase):
         self.assertEqual(c(e1=False, v1=1, v2=1), 0)
         self.assertEqual(c(e1=False, v1=1, v2=2), 0)
 
+    def test_multiline_intention_constraint(self):
+        self.dcop_str += """
+        constraints:
+          cond:
+            type: intention
+            function: | 
+              if e1:
+                  b = v1 * 2
+              else:
+                  b = 0
+              return b + v2
+        """
+
+        dcop = load_dcop(self.dcop_str)
+
+        self.assertEqual(len(dcop.constraints), 1)
+        c = dcop.constraint("cond")
+        self.assertEqual(c.name, "cond")
+        self.assertEqual(c(e1=True, v1=1, v2=1), 3)
+        self.assertEqual(c(e1=True, v1=1, v2=2), 4)
+        self.assertEqual(c(e1=False, v1=1, v2=1), 1)
+        self.assertEqual(c(e1=False, v1=1, v2=2), 2)
+
     def test_extensional_constraint_one_var(self):
         self.dcop_str += """
         constraints:

--- a/tests/unit/test_utils_expressionfunction.py
+++ b/tests/unit/test_utils_expressionfunction.py
@@ -238,3 +238,41 @@ return c
     assert has_return
     assert exp_vars == {"a", "b"}
 
+
+def test_multiline_expression_starting_with_newline():
+    exp = ExpressionFunction("""
+a=3
+return a""")
+
+    assert exp() == 3
+
+
+def test_multiline_expression_no_newline_at_start():
+    exp = ExpressionFunction("""a=3
+return a + 2""")
+
+    assert exp() == 5
+
+    # As f has no arg, it must raise an error :
+    with pytest.raises(TypeError):
+        exp(a=4, b=3, c=2)
+    with pytest.raises(TypeError):
+        exp(a=4)
+    with pytest.raises(TypeError):
+        exp(4)
+
+
+def test_multiline_expression_one_var():
+    exp = ExpressionFunction("""a=3
+return a * b""")
+
+    assert exp(b=2) == 6
+
+    with pytest.raises(TypeError) as exception:
+        exp()
+    assert "Missing named argument(s)" in str(exception.value)
+
+    with pytest.raises(TypeError) as exception:
+        exp(4)
+    assert "takes 1 positional argument but 2 were given" in str(exception.value)
+

--- a/tests/unit/test_utils_expressionfunction.py
+++ b/tests/unit/test_utils_expressionfunction.py
@@ -34,7 +34,7 @@ from functools import partial
 
 import pytest
 
-from pydcop.utils.expressionfunction import ExpressionFunction
+from pydcop.utils.expressionfunction import ExpressionFunction, _analyse_ast
 from pydcop.utils.simple_repr import simple_repr, from_repr
 
 
@@ -186,3 +186,55 @@ def test_type_error_on_excessive_assignment():
 
     with pytest.raises(TypeError):
         f(a=4, b=3, c=2)
+
+
+def test_analyse_ast_simple_expr_no_variable():
+    has_return, exp_vars = _analyse_ast("3 ")
+    assert not has_return
+    assert exp_vars == set()
+
+
+def test_analyse_ast_simple_expr_one_variable():
+    has_return, exp_vars = _analyse_ast("a + 3 ")
+    assert not has_return
+    assert exp_vars == { "a"}
+
+
+def test_analyse_ast_simple_expr_two_variable():
+    has_return, exp_vars = _analyse_ast("a + b ")
+    assert not has_return
+    assert exp_vars == { "a", "b"}
+
+
+def test_analyse_ast_simple_if_expr():
+    has_return, exp_vars = _analyse_ast("10 if a == b  else 0")
+    assert not has_return
+    assert exp_vars == { "a", "b"}
+
+
+def test_analyse_ast_func_no_variable():
+    has_return, exp_vars = _analyse_ast("""
+a = 3
+return a
+""")
+    assert has_return
+    assert exp_vars == set()
+
+
+def test_analyse_ast_func_one_variable():
+    has_return, exp_vars = _analyse_ast("""
+a = 3
+return a + b
+""")
+    assert has_return
+    assert exp_vars == {"b"}
+
+
+def test_analyse_ast_func_two_variable():
+    has_return, exp_vars = _analyse_ast("""
+c = 10 *a + 5 * b
+return c
+""")
+    assert has_return
+    assert exp_vars == {"a", "b"}
+


### PR DESCRIPTION
This PR implements the support for constraints defined as full python functions, written in yaml dcop definition file.
