### PR TITLE
Support for constraints defined in external python file

### DIFF
--- a/docs/usage/file_formats/dcop_format.yml
+++ b/docs/usage/file_formats/dcop_format.yml
@@ -105,7 +105,7 @@ constraints:
     function: 1000 if var2 == var3 else 0
   c4:
     type: intention
-    # this is an example of a multi-line intentional constraints
+    # This is an example of a multi-line intentional constraints:
     # The `function` if a full python function
     # Real hard constraints are not supported, you can emulate them by defining
     # constraints as a full python function. The `def` line is omitted and will be
@@ -119,6 +119,18 @@ constraints:
       else:
           b = 2
       return var1 + 2
+
+  diff_2_3:
+    type: intention
+    # Example of an intentional constraints defined as a function in an external file
+    # The `source` entry must point to a valid python file that containts a definition
+    # of a function implementing the constraint. Relative or absolute path can be used,
+    # when using a relative path, the actual path is based on the location of the dcop
+    # yaml file. When defining a dcop in several yaml files, the actual path is based
+    # on the location of the first yaml file.
+    source: "./external_python_constraints.py"
+    #
+    function: source.diff_vars(v2, v3)
 
   cost_d1:
     type: intention

--- a/pydcop/dcop/relations.py
+++ b/pydcop/dcop/relations.py
@@ -1311,6 +1311,25 @@ def constraint_from_str(name: str, expression: str, all_variables: Iterable[Vari
 # should be used.
 relation_from_str = constraint_from_str
 
+def constraint_from_external_definition(name: str,
+        source_file: str, expression: str, all_variables: Iterable[Variable]):
+
+    f_exp = ExpressionFunction(expression, source_file)
+    relation_variables = []
+    for v in f_exp.variable_names:
+        found = False
+        for s in all_variables:
+            if s.name == v:
+                relation_variables.append(s)
+                found = True
+        if not found:
+            raise Exception(
+                "Missing variable {} for string-based function "
+                '"{}"'.format(v, expression)
+            )
+
+    return NAryFunctionRelation(f_exp, relation_variables, name, f_kwargs=True)
+
 
 def add_var_to_rel(
     name: str, original_relation: RelationProtocol, variable: Variable, f

--- a/tests/instances/external_python_constraints.py
+++ b/tests/instances/external_python_constraints.py
@@ -1,0 +1,12 @@
+
+
+def diff_vars(a, b):
+    """
+    This is an example of a constraint defined as a python function, in an external file.
+    See `graph_coloring1_func.yaml` for an example on how to use such constraint in
+    a yaml dcop file.
+    """
+    if a == b:
+        return 1
+    else:
+        return 0

--- a/tests/instances/graph_coloring1_func.yaml
+++ b/tests/instances/graph_coloring1_func.yaml
@@ -1,0 +1,49 @@
+name: graph coloring
+objective: min
+
+domains:
+  colors:
+    values: [R, G]
+    type: 'color'
+
+variables:
+  v1:
+    domain: colors
+    cost_function: -0.1 if v1 == 'R' else 0.1
+  v2:
+    domain: colors
+    cost_function: -0.1 if v2 == 'G' else 0.1
+  v3:
+    domain: colors
+    cost_function: -0.1 if v3 == 'G' else 0.1
+
+constraints:
+  diff_1_2: 
+    type: intention
+    function: |
+      if v1 == v2:
+          return 1
+      else:
+          return 0
+  diff_2_3: 
+    type: intention
+    source: "./external_python_constraints.py"
+    function: source.diff_vars(v2, v3)
+
+agents:
+  a1:
+    capacity: 100
+  a2:
+    capacity: 100
+  a3:
+    capacity: 100
+  a4:
+    capacity: 100
+  a5:
+    capacity: 100 
+
+distribution_hints:
+  must_host:
+    a1: [v1]
+    a2: [v2]
+    a3: [v3]

--- a/tests/unit/test_utils_expressionfunction.py
+++ b/tests/unit/test_utils_expressionfunction.py
@@ -276,3 +276,24 @@ return a * b""")
         exp(4)
     assert "takes 1 positional argument but 2 were given" in str(exception.value)
 
+
+def test_multiline_expression_with_import():
+    exp = ExpressionFunction("""import math
+return math.pi + a""")
+
+    import math
+    assert exp(a=2) == math.pi + 2
+
+    with pytest.raises(TypeError) as exception:
+        exp(2)
+
+
+def test_multiline_expression_with_fromimport():
+    exp = ExpressionFunction("""from math import pi
+return pi + a""")
+
+    import math
+    assert exp(a=2) == math.pi + 2
+
+    with pytest.raises(TypeError) as exception:
+        exp(2)


### PR DESCRIPTION
With these improvements, one can now use constraints defined as full python function, in ewternal python code.

In the yaml DCOP definition, the constraints declaration looks like this: 

````yaml
constraints:
  diff_2_3:
    type: intention
    # Example of an intentional constraints defined as a function in an external file
    # The `source` entry must point to a valid python file that containts a definition
    # of a function implementing the constraint. Relative or absolute path can be used,
    # when using a relative path, the actual path is based on the location of the dcop
    # yaml file. When defining a dcop in several yaml files, the actual path is based
    # on the location of the first yaml file.
    source: "./external_python_constraints.py"
    #
    function: source.diff_vars(v2, v3)
````