### PR TITLE
FIX: slice operation for  source files of relation

### DIFF
--- a/pydcop/dcop/relations.py
+++ b/pydcop/dcop/relations.py
@@ -580,6 +580,11 @@ class NAryFunctionRelation(AbstractBaseRelation, SimpleRepr):
             else:
                 slice_f = functools.partial(self._f, **slicing_dict)
 
+            # Check if there is a source file for the relation defined
+            if 'source' in self._f.exp_func.__globals__:
+                # Add the source object
+                slice_f.exp_func.__globals__['source'] = self._f.exp_func.__globals__['source']
+
             return NAryFunctionRelation(slice_f, remaining_vars, name=self.name)
 
     def set_value_for_assignment(self, assignment, relation_value):


### PR DESCRIPTION
Within the slice operation, of the NAryFunctionRelation class, the source file was not correctly transferred to the newly created relation.