### PR TITLE
Implementation of Continuous DCOP objects

### DIFF
--- a/docs/usage/file_formats/dcop_format.yml
+++ b/docs/usage/file_formats/dcop_format.yml
@@ -29,7 +29,6 @@ domains:
   d3:
     values  : [1 .. 10]
     type   : non_semantic
-    initial_value: 3
   dbool:
     values  : [true, false]
 

--- a/pydcop/algorithms/adsa.py
+++ b/pydcop/algorithms/adsa.py
@@ -83,6 +83,7 @@ import random
 from typing import Tuple, Any, List, Dict
 
 from pydcop.algorithms import AlgoParameterDef, ComputationDef
+from pydcop.dcop.objects import Domain
 from pydcop.dcop.relations import (
     find_optimum,
     assignment_cost,
@@ -134,6 +135,8 @@ class ADsaComputation(VariableComputation):
 
         assert comp_def.algo.algo == "adsa"
         assert (comp_def.algo.mode == "min") or (comp_def.algo.mode == "max")
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
 
         self.mode = comp_def.algo.mode
         self.probability = comp_def.algo.param_value("probability")

--- a/pydcop/algorithms/amaxsum.py
+++ b/pydcop/algorithms/amaxsum.py
@@ -72,7 +72,7 @@ import logging
 from collections import defaultdict
 from typing import Dict, Any, List
 
-from pydcop.dcop.objects import VariableNoisyCostFunc, Variable
+from pydcop.dcop.objects import VariableNoisyCostFunc, Variable, Domain
 from pydcop.algorithms import AlgoParameterDef, ComputationDef
 from pydcop.algorithms import maxsum
 from pydcop.dcop.relations import generate_assignment_as_dict
@@ -114,6 +114,9 @@ class MaxSumFactorComputation(DcopComputation):
     def __init__(self, comp_def=None):
         assert comp_def.algo.algo == "amaxsum"
         super().__init__(comp_def.node.factor.name, comp_def)
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
+        
         self.mode = comp_def.algo.mode
         self.factor = comp_def.node.factor
         self.variables = self.factor.dimensions

--- a/pydcop/algorithms/dba.py
+++ b/pydcop/algorithms/dba.py
@@ -107,7 +107,7 @@ from pydcop.infrastructure.computations import Message, VariableComputation, \
 
 from pydcop.computations_graph.constraints_hypergraph import \
     VariableComputationNode
-from pydcop.dcop.objects import Variable
+from pydcop.dcop.objects import Variable, Domain
 from pydcop.dcop.relations import RelationProtocol, filter_assignment_dict
 
 INFINITY = 10000
@@ -296,7 +296,9 @@ class DbaComputation(VariableComputation):
             raise ValueError('DBA is a constraint **satisfaction** '
                              'algorithm and only support '
                              'minimization objective')
-
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
+        
         self._msg_sender = msg_sender
 
         global INFINITY

--- a/pydcop/algorithms/dpop.py
+++ b/pydcop/algorithms/dpop.py
@@ -58,7 +58,7 @@ from typing import Iterable
 
 from pydcop.computations_graph.pseudotree import get_dfs_relations
 from pydcop.infrastructure.computations import Message, VariableComputation, register
-from pydcop.dcop.objects import Variable
+from pydcop.dcop.objects import Variable, Domain
 from pydcop.dcop.relations import (
     NAryMatrixRelation,
     Constraint,
@@ -172,11 +172,13 @@ class DpopAlgo(VariableComputation):
     """
 
     def __init__(self, comp_def: ComputationDef):
-
         assert comp_def.algo.algo == "dpop"
 
         super().__init__(comp_def.node.variable, comp_def)
         self._mode = comp_def.algo.mode
+
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
 
         self._parent, self._pseudo_parents, self._children, self._pseudo_children = get_dfs_relations(
             self.computation_def.node

--- a/pydcop/algorithms/dsa.py
+++ b/pydcop/algorithms/dsa.py
@@ -97,7 +97,7 @@ import random
 
 from pydcop.algorithms import AlgoParameterDef, ComputationDef
 from pydcop.infrastructure.computations import Message, VariableComputation, register
-
+from pydcop.dcop.objects import Domain
 from pydcop.computations_graph.constraints_hypergraph import VariableComputationNode
 from pydcop.dcop.relations import (
     find_optimum,
@@ -247,6 +247,8 @@ class DsaComputation(VariableComputation):
 
         assert comp_def.algo.algo == "dsa"
         assert (comp_def.algo.mode == "min") or (comp_def.algo.mode == "max")
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
 
         self.mode = comp_def.algo.mode
         self.probability = comp_def.algo.param_value("probability")

--- a/pydcop/algorithms/dsatuto.py
+++ b/pydcop/algorithms/dsatuto.py
@@ -50,6 +50,7 @@ from numpy import random
 
 from pydcop.algorithms import ComputationDef
 from pydcop.dcop.relations import assignment_cost, find_optimal
+from pydcop.dcop.objects import Domain
 from pydcop.infrastructure.computations import (
     VariableComputation,
     message_type,
@@ -82,6 +83,9 @@ class DsaTutoComputation(SynchronousComputationMixin, VariableComputation):
         super().__init__(computation_definition.node.variable, computation_definition)
 
         assert computation_definition.algo.algo == "dsatuto"
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
+        
         self.mode = computation_definition.algo.mode
 
         self.constraints = computation_definition.node.constraints

--- a/pydcop/algorithms/gdba.py
+++ b/pydcop/algorithms/gdba.py
@@ -46,7 +46,7 @@ from typing import Iterable, Dict, Any, Tuple
 from pydcop.algorithms import AlgoParameterDef, ComputationDef
 from pydcop.infrastructure.computations import Message, VariableComputation, register
 from pydcop.computations_graph.constraints_hypergraph import VariableComputationNode
-from pydcop.dcop.objects import Variable
+from pydcop.dcop.objects import Variable, Domain
 from pydcop.dcop.relations import (
     RelationProtocol,
     NAryMatrixRelation,
@@ -232,6 +232,8 @@ class GdbaComputation(VariableComputation):
         """
 
         super().__init__(variable, comp_def)
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
 
         self._msg_sender = msg_sender
 

--- a/pydcop/algorithms/maxsum.py
+++ b/pydcop/algorithms/maxsum.py
@@ -90,7 +90,7 @@ from pydcop.computations_graph.factor_graph import (
     FactorComputationNode,
     VariableComputationNode,
 )
-from pydcop.dcop.objects import Variable, VariableNoisyCostFunc
+from pydcop.dcop.objects import Variable, VariableNoisyCostFunc, Domain
 from pydcop.dcop.relations import Constraint, generate_assignment_as_dict
 from pydcop.infrastructure.computations import (
     DcopComputation,
@@ -280,7 +280,10 @@ class MaxSumFactorComputation(SynchronousComputationMixin, DcopComputation):
     def __init__(self, comp_def: ComputationDef):
         assert comp_def.algo.algo == "maxsum"
         super().__init__(comp_def.node.factor.name, comp_def)
-        self.logger.warning(f"Neiborghs {self.neighbors}")
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
+
+        self.logger.warning(f"Neighbors {self.neighbors}")
 
         self.mode = comp_def.algo.mode
         self.factor = comp_def.node.factor

--- a/pydcop/algorithms/maxsum_dynamic.py
+++ b/pydcop/algorithms/maxsum_dynamic.py
@@ -35,6 +35,7 @@ from pydcop.infrastructure.computations import Message, register
 from pydcop.algorithms.amaxsum import MaxSumFactorComputation, MaxSumVariableComputation
 from pydcop.algorithms.maxsum import MaxSumMessage
 from pydcop.dcop.relations import NeutralRelation
+from pydcop.dcop.objects import Domain
 
 
 class DynamicFunctionFactorComputation(MaxSumFactorComputation):
@@ -76,6 +77,8 @@ class DynamicFunctionFactorComputation(MaxSumFactorComputation):
 
     def __init__(self, comp_def=None):
         super().__init__(comp_def=comp_def)
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
 
     def change_factor_function(self, fn):
         """

--- a/pydcop/algorithms/mgm.py
+++ b/pydcop/algorithms/mgm.py
@@ -63,6 +63,7 @@ from pydcop.dcop.relations import (
     find_arg_optimal,
     optimal_cost_value,
 )
+from pydcop.dcop.objects import Domain
 from pydcop.infrastructure.computations import Message, VariableComputation, register
 
 GRAPH_TYPE = "constraints_hypergraph"
@@ -231,6 +232,8 @@ class MgmComputation(VariableComputation):
         )
 
         super().__init__(computation_definition.node.variable, computation_definition)
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
 
         self.__utilities__ = list(computation_definition.node.constraints)
         self._mode = computation_definition.algo.mode  # min or max

--- a/pydcop/algorithms/mgm2.py
+++ b/pydcop/algorithms/mgm2.py
@@ -46,7 +46,7 @@ from typing import Dict, Any, Tuple, List
 
 from pydcop.algorithms import AlgoParameterDef, ComputationDef
 from pydcop.infrastructure.computations import Message, VariableComputation, register
-
+from pydcop.dcop.objects import Domain
 from pydcop.computations_graph.constraints_hypergraph import VariableComputationNode
 from pydcop.dcop.relations import (
     find_dependent_relations,
@@ -417,6 +417,8 @@ class Mgm2Computation(VariableComputation):
     def __init__(self, computation_def: ComputationDef = None):
         assert computation_def.algo.algo == "mgm2"
         super().__init__(computation_def.node.variable, computation_def)
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
 
         self._mode = computation_def.algo.mode
         self.stop_cycle = computation_def.algo.param_value("stop_cycle")

--- a/pydcop/algorithms/mixeddsa.py
+++ b/pydcop/algorithms/mixeddsa.py
@@ -38,7 +38,7 @@ from typing import Dict, List, Tuple
 
 from pydcop.dcop.relations import RelationProtocol, generate_assignment_as_dict, \
     filter_assignment_dict
-
+from pydcop.dcop.objects import Domain
 from pydcop.algorithms import AlgoParameterDef, ComputationDef
 from pydcop.infrastructure.computations import Message, VariableComputation, \
     register
@@ -183,6 +183,8 @@ class MixedDsaComputation(VariableComputation):
 
         """
         super().__init__(variable, comp_def)
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
 
         self.proba_hard = proba_hard
         self.proba_soft = proba_soft

--- a/pydcop/algorithms/ncbb.py
+++ b/pydcop/algorithms/ncbb.py
@@ -102,6 +102,7 @@ from typing import Optional, List
 
 from pydcop.algorithms import ComputationDef
 from pydcop.computations_graph.pseudotree import get_dfs_relations
+from pydcop.dcop.objects import Domain
 from pydcop.dcop.relations import find_optimal
 from pydcop.infrastructure.computations import (
     VariableComputation,
@@ -149,7 +150,8 @@ class NcbbAlgo(SynchronousComputationMixin, VariableComputation):
 
     def __init__(self, computation_definition: ComputationDef):
         super().__init__(computation_definition.node.variable, computation_definition)
-
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
         assert computation_definition.algo.algo == "ncbb"
         self._mode = computation_definition.algo.mode
 

--- a/pydcop/algorithms/syncbb.py
+++ b/pydcop/algorithms/syncbb.py
@@ -149,7 +149,7 @@ Computation
 from typing import Optional, List, Any, Tuple
 
 from pydcop.algorithms import ComputationDef
-from pydcop.dcop.objects import Variable
+from pydcop.dcop.objects import Variable, Domain
 from pydcop.dcop.relations import assignment_cost, Constraint
 from pydcop.infrastructure.computations import (
     VariableComputation,
@@ -181,6 +181,8 @@ class SyncBBComputation(VariableComputation):
 
     def __init__(self, computation_definition: ComputationDef):
         super().__init__(computation_definition.node.variable, computation_definition)
+        # Check if the domains of the variables are suitable
+        assert type(self._variable.domain) is Domain
 
         assert computation_definition.algo.algo == "syncbb"
         self.constraints = computation_definition.node.constraints

--- a/pydcop/dcop/objects.py
+++ b/pydcop/dcop/objects.py
@@ -165,6 +165,51 @@ class Domain(Sized, SimpleRepr, Iterable[Any]):
         raise ValueError(str(val) + " is not in the domain " + self._name)
 
 
+class ContinuousDomain(Domain):
+    """
+    A ContinuousDomain indicates the lower and upper bound of the values 
+    that are valid for variables with this domain. 
+    It also indicates the type of environment state represented
+    by there variable : 'luminosity', humidity', etc.
+
+    The lower and upper bound of the domain is stored separately
+    as well as within the values (values = [lower bound, upper bound])
+    in order to be compatible with the Domain class.
+    """
+
+    def __init__(self, name: str, domain_type: str, lower_bound: float, upper_bound: float) -> None:
+        """
+
+        :param: name: name of the domain.
+        :param domain_type: a string identifying the kind of value in the
+                            domain. For example : 'luminosity', 'humidity', ...
+        :param lower_bound: the lower bound of the domain of the valid values
+        :param upper_bound: the upper bound of the domain of the valid values
+        """
+        # Check the bounds for consistency
+        assert lower_bound <= upper_bound
+
+        # Initiate the parent class
+        super().__init__(name, domain_type, [lower_bound, upper_bound])
+
+        # Store the parameters
+        self._lower_bound = lower_bound
+        self._upper_bound = upper_bound
+
+    @property
+    def upper_bound(self) -> float:
+        return self._upper_bound
+
+    @property
+    def lower_bound(self) -> float:
+        return self._lower_bound
+
+    def __str__(self):
+        return f"ContinuousDomain({self.name})"
+
+    def __repr__(self):
+        return f"ContinuousDomain({self.name}, {self.type}, ({self.lower_bound}..{self.upper_bound}))"
+
 # We keep VariableDomain as an alias for the moment, but Domain should be
 # preferred.
 VariableDomain = Domain

--- a/tests/dcop/test_load_dcop.py
+++ b/tests/dcop/test_load_dcop.py
@@ -1,0 +1,100 @@
+"""
+
+Tests for loading DCOP yaml files.
+
+These tests check for correct parsing of the DCOP definition files.
+
+"""
+import unittest
+from pydcop.dcop.yamldcop import load_dcop_from_file, load_dcop
+from pydcop.dcop.objects import (
+    ContinuousDomain,
+    Domain,
+)
+
+dcop_test_str = """
+    name: 'dcop test'
+    description: 'Testing of DCOP yaml parsing'
+    objective: min
+
+    domains: 
+        dint:
+            values  : [0, 1, 2, 3, 4]
+            type   : non_semantic
+        dstr:
+            values  : ['A', 'B', 'C', 'D', 'E']
+        dcont:
+            values  : [0 .. 1]
+            type   : non_semantic
+            initial_value: 3
+        dbool:
+            values  : [true, false]
+
+    variables:
+        var1:
+            domain: dint
+            initial_value: 0
+            yourkey: yourvalue
+            foo: bar
+        var2:
+            domain: dstr
+            initial_value: 'A'
+        var3:
+            domain: dint
+            initial_value: 0
+            cost_function: var3 * 0.5
+        var4:
+            domain: dcont
+            initial_value: 0
+            cost_function: var4 * 0.6
+    
+    external_variables:
+        ext_var1:
+            domain: dbool
+            initial_value: False
+
+    constraints:
+        c1:
+            type: intention
+            function: var3 - var1
+
+    agents:
+        a1:
+            capacity: 100
+        a2:
+            capacity: 100
+        a3:
+            capacity: 100
+        a4:
+            capacity: 100
+"""
+
+class TestDomains(unittest.TestCase):
+
+    def test_classes(self):
+        # Load the DCOP
+        dcop = load_dcop(dcop_test_str)
+        
+        # Check the classes
+        self.assertIsInstance(dcop.domains['dint'], Domain)
+        self.assertIsInstance(dcop.domains['dstr'], Domain)
+        self.assertIsInstance(dcop.domains['dcont'], ContinuousDomain)
+        self.assertIsInstance(dcop.domains['dbool'], Domain)
+
+    def test_values(self):
+        # Load the DCOP
+        dcop = load_dcop(dcop_test_str)
+
+        # Check the values
+        self.assertEqual(dcop.domains['dint'].values, (0, 1, 2, 3, 4))
+        self.assertEqual(dcop.domains['dstr'].values, ('A', 'B', 'C', 'D', 'E'))
+        self.assertEqual(dcop.domains['dcont'].values, (0.0, 1.0))
+        self.assertEqual(dcop.domains['dbool'].values, (True, False))
+
+    def test_bounds(self):
+        # Load the DCOP
+        dcop = load_dcop(dcop_test_str)
+
+        # Check the bounds
+        self.assertEqual(dcop.domains['dcont'].lower_bound, 0.0)
+        self.assertEqual(dcop.domains['dcont'].upper_bound, 1.0)


### PR DESCRIPTION
Created a continuous domain class and updated the parsing of the DCOP yaml files.
Continuous domains are created by [0 .. 10] to indicate a lower bound of '0' and a upper bound of '10'.
Within all existing algorithms a check is added to assert the use of discrete domains for the local variables.