### PR TITLE
Clamp pyyaml and PuLP versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,10 @@
 
 # Basic dependencies, required to run pyDCOP:
 deps = [
-        'pulp',
+        'pulp==2.0',
         'numpy',
         'networkx',
-        'pyyaml',
+        'pyyaml==5.4.1',
         'requests',
         'websocket-server',
         'tqdm',


### PR DESCRIPTION
The latest versions available from pypi break pydcop.

Fixes #37 #38

Just a stopgap, though: code should be updated to the latest library APIs.